### PR TITLE
Add blog listing and post layout components

### DIFF
--- a/apps/web-frontend/content/blog/index.mdx
+++ b/apps/web-frontend/content/blog/index.mdx
@@ -3,4 +3,6 @@ title: "Blog"
 date: "2026-04-30"
 ---
 
-All blog posts will be listed here. Check back soon for updates!
+import { BlogListing } from "@/components/blog-listing";
+
+<BlogListing posts={props.blogPosts} client:load />

--- a/apps/web-frontend/content/index.mdx
+++ b/apps/web-frontend/content/index.mdx
@@ -6,6 +6,7 @@ date: "2026-04-30"
 import { Hero1 } from "@/components/hero1";
 import { ItemsBlock } from "@/components/items-block";
 import { ServerListBlock } from "@/components/server-list-block";
+import { BlogListingMinimal } from "@/components/blog-listing-minimal";
 
 import {
   RiApps2Line,
@@ -82,3 +83,6 @@ import {
     },
   ]}
 />
+
+{/* Recent blog posts */}
+<BlogListingMinimal posts={props.blogPosts} />

--- a/apps/web-frontend/src/components/blog-listing-minimal.tsx
+++ b/apps/web-frontend/src/components/blog-listing-minimal.tsx
@@ -1,0 +1,127 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { siteConfig } from "@/site.config";
+import { cn } from "@/lib/utils";
+import { RiArrowRightLine, RiCalendarLine, RiUser3Line } from "@remixicon/react";
+import type { BlogPost } from "@/components/blog-listing";
+
+const topicLabels: Record<string, string> = {
+  "general": "General",
+  "server/minigames": "Minigames",
+  "server/modded-creative": "Modded Creative",
+  "server/survival": "Survival",
+};
+
+interface BlogListingMinimalProps {
+  posts: BlogPost[];
+  className?: string;
+}
+
+const BlogListingMinimal = ({ posts, className }: BlogListingMinimalProps) => {
+  const recent = [...posts]
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, 5);
+
+  return (
+    <section className={cn("py-24", className)}>
+      <div className="container mx-auto">
+        <div className="space-y-8">
+          {/* Heading row */}
+          <div className="flex items-end justify-between gap-4">
+            <div className="space-y-1">
+              <h2 className="text-3xl font-semibold tracking-tight lg:text-5xl">
+                Latest from the blog
+              </h2>
+              <p className="text-muted-foreground">
+                Catch up on the most recent posts from the Miners Online team.
+              </p>
+            </div>
+            <Button asChild variant="outline" className="hidden shrink-0 sm:inline-flex">
+              <a href="/blog">
+                All posts
+                <RiArrowRightLine className="size-4" />
+              </a>
+            </Button>
+          </div>
+
+          {/* Post list */}
+          <div className="divide-y divide-border">
+            {recent.map((post) => (
+              <MinimalPostRow key={post.id} post={post} />
+            ))}
+          </div>
+
+          {/* Mobile "All posts" button */}
+          <div className="sm:hidden">
+            <Button asChild variant="outline" className="w-full">
+              <a href="/blog">
+                All posts
+                <RiArrowRightLine className="size-4" />
+              </a>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const MinimalPostRow = ({ post }: { post: BlogPost }) => {
+  const formattedDate = new Date(post.date).toLocaleDateString("en-GB", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  const resolvedAuthors = post.authors.map((key) => {
+    const author = siteConfig.blog.authors[key];
+    return author ? author.name : key;
+  });
+
+  const href = `/blog/${post.id}`;
+
+  return (
+    <article className="group flex flex-col gap-3 py-5 sm:flex-row sm:items-center sm:gap-6">
+      {/* Topic badge — always visible, left-aligned or top on mobile */}
+      <div className="flex shrink-0 gap-1.5">
+        {post.topics.map((topic) => (
+          <Badge key={topic} variant="secondary">
+            {topicLabels[topic] ?? topic}
+          </Badge>
+        ))}
+      </div>
+
+      {/* Title + meta */}
+      <div className="flex flex-1 flex-col gap-1 min-w-0">
+        <a
+          href={href}
+          className="font-semibold leading-snug text-pretty transition-colors hover:text-primary line-clamp-2"
+        >
+          {post.title}
+        </a>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <RiCalendarLine className="size-3.5" />
+            <time dateTime={post.date}>{formattedDate}</time>
+          </span>
+          <span className="flex items-center gap-1">
+            <RiUser3Line className="size-3.5" />
+            {resolvedAuthors.join(", ")}
+          </span>
+        </div>
+      </div>
+
+      {/* Arrow link */}
+      <a
+        href={href}
+        aria-label={`Read ${post.title}`}
+        className="hidden shrink-0 text-muted-foreground transition-colors hover:text-foreground sm:block"
+      >
+        <RiArrowRightLine className="size-5" />
+      </a>
+    </article>
+  );
+};
+
+export { BlogListingMinimal };
+export type { BlogListingMinimalProps };

--- a/apps/web-frontend/src/components/blog-listing-minimal.tsx
+++ b/apps/web-frontend/src/components/blog-listing-minimal.tsx
@@ -44,10 +44,10 @@ const BlogListingMinimal = ({ posts, className }: BlogListingMinimalProps) => {
             </Button>
           </div>
 
-          {/* Post list */}
-          <div className="divide-y divide-border">
+          {/* Card grid */}
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {recent.map((post) => (
-              <MinimalPostRow key={post.id} post={post} />
+              <MinimalPostCard key={post.id} post={post} />
             ))}
           </div>
 
@@ -66,7 +66,7 @@ const BlogListingMinimal = ({ posts, className }: BlogListingMinimalProps) => {
   );
 };
 
-const MinimalPostRow = ({ post }: { post: BlogPost }) => {
+const MinimalPostCard = ({ post }: { post: BlogPost }) => {
   const formattedDate = new Date(post.date).toLocaleDateString("en-GB", {
     year: "numeric",
     month: "short",
@@ -78,47 +78,49 @@ const MinimalPostRow = ({ post }: { post: BlogPost }) => {
     return author ? author.name : key;
   });
 
-  const href = `/blog/${post.id}`;
+  const href = `/${post.id}`;
 
   return (
-    <article className="group flex flex-col gap-3 py-5 sm:flex-row sm:items-center sm:gap-6">
-      {/* Topic badge — always visible, left-aligned or top on mobile */}
-      <div className="flex shrink-0 gap-1.5">
-        {post.topics.map((topic) => (
-          <Badge key={topic} variant="secondary">
-            {topicLabels[topic] ?? topic}
-          </Badge>
-        ))}
-      </div>
+    <article className="group flex h-full flex-col rounded-md border border-border bg-card p-6 transition-colors hover:border-primary/40">
+      {/* Topics */}
+      {post.topics.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {post.topics.map((topic) => (
+            <Badge key={topic} variant="secondary">
+              {topicLabels[topic] ?? topic}
+            </Badge>
+          ))}
+        </div>
+      )}
 
-      {/* Title + meta */}
-      <div className="flex flex-1 flex-col gap-1 min-w-0">
-        <a
-          href={href}
-          className="font-semibold leading-snug text-pretty transition-colors hover:text-primary line-clamp-2"
-        >
+      {/* Title */}
+      <h3 className="text-base font-semibold tracking-tight leading-snug text-pretty">
+        <a href={href} className="hover:text-primary transition-colors">
           {post.title}
         </a>
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
-          <span className="flex items-center gap-1">
-            <RiCalendarLine className="size-3.5" />
-            <time dateTime={post.date}>{formattedDate}</time>
-          </span>
-          <span className="flex items-center gap-1">
-            <RiUser3Line className="size-3.5" />
-            {resolvedAuthors.join(", ")}
-          </span>
-        </div>
-      </div>
+      </h3>
 
-      {/* Arrow link */}
-      <a
-        href={href}
-        aria-label={`Read ${post.title}`}
-        className="hidden shrink-0 text-muted-foreground transition-colors hover:text-foreground sm:block"
-      >
-        <RiArrowRightLine className="size-5" />
-      </a>
+      {/* Description */}
+      {post.description && (
+        <p className="mt-2 text-sm text-muted-foreground leading-relaxed line-clamp-2">
+          {post.description}
+        </p>
+      )}
+
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* Metadata */}
+      <div className="mt-6 flex flex-wrap items-center gap-x-4 gap-y-1 border-t border-border pt-4 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <RiCalendarLine className="size-3.5" />
+          <time dateTime={post.date}>{formattedDate}</time>
+        </span>
+        <span className="flex items-center gap-1">
+          <RiUser3Line className="size-3.5" />
+          {resolvedAuthors.join(", ")}
+        </span>
+      </div>
     </article>
   );
 };

--- a/apps/web-frontend/src/components/blog-listing.tsx
+++ b/apps/web-frontend/src/components/blog-listing.tsx
@@ -187,7 +187,7 @@ const BlogPostCard = ({ post }: { post: BlogPost }) => {
     return author ? author.name : key;
   });
 
-  const href = `/blog/${post.id}`;
+  const href = `/${post.id}`;
 
   return (
     <article className="flex h-full flex-col rounded-md border border-border bg-card p-6">

--- a/apps/web-frontend/src/components/blog-listing.tsx
+++ b/apps/web-frontend/src/components/blog-listing.tsx
@@ -1,0 +1,258 @@
+import { useState, useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { siteConfig } from "@/site.config";
+import { cn } from "@/lib/utils";
+import {
+  RiArrowRightLine,
+  RiCalendarLine,
+  RiSearchLine,
+  RiUser3Line,
+  RiCloseLine,
+} from "@remixicon/react";
+
+const topicLabels: Record<string, string> = {
+  "general": "General",
+  "server/minigames": "Minigames",
+  "server/modded-creative": "Modded Creative",
+  "server/survival": "Survival",
+};
+
+export interface BlogPost {
+  id: string;
+  title: string;
+  description?: string;
+  date: string;
+  authors: string[];
+  topics: string[];
+  tags?: string[];
+}
+
+interface BlogListingProps {
+  posts: BlogPost[];
+  className?: string;
+}
+
+const BlogListing = ({ posts, className }: BlogListingProps) => {
+  const [search, setSearch] = useState("");
+  const [activeTopic, setActiveTopic] = useState<string | null>(null);
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+
+  // Derive all unique topics and tags from posts
+  const allTopics = useMemo(() => {
+    const set = new Set<string>();
+    posts.forEach((p) => p.topics.forEach((t) => set.add(t)));
+    return Array.from(set).sort();
+  }, [posts]);
+
+  const allTags = useMemo(() => {
+    const set = new Set<string>();
+    posts.forEach((p) => p.tags?.forEach((t) => set.add(t)));
+    return Array.from(set).sort();
+  }, [posts]);
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    return posts
+      .filter((p) => {
+        if (activeTopic && !p.topics.includes(activeTopic)) return false;
+        if (activeTag && !(p.tags ?? []).includes(activeTag)) return false;
+        if (q) {
+          return (
+            p.title.toLowerCase().includes(q) ||
+            (p.description ?? "").toLowerCase().includes(q) ||
+            (p.tags ?? []).some((t) => t.toLowerCase().includes(q))
+          );
+        }
+        return true;
+      })
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  }, [posts, search, activeTopic, activeTag]);
+
+  const hasActiveFilters = !!activeTopic || !!activeTag || !!search;
+
+  const clearFilters = () => {
+    setSearch("");
+    setActiveTopic(null);
+    setActiveTag(null);
+  };
+
+  return (
+    <section className={cn("py-16", className)}>
+      <div className="container mx-auto px-4">
+        <div className="space-y-10">
+          {/* Heading */}
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold tracking-tight lg:text-5xl">Blog</h1>
+            <p className="text-muted-foreground lg:text-lg">
+              Updates, announcements, and stories from the Miners Online team.
+            </p>
+          </div>
+
+          {/* Filters */}
+          <div className="space-y-4">
+            {/* Search */}
+            <div className="relative max-w-sm">
+              <RiSearchLine className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder="Search posts..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+
+            {/* Topic filters */}
+            {allTopics.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {allTopics.map((topic) => (
+                  <button
+                    key={topic}
+                    onClick={() =>
+                      setActiveTopic((prev) => (prev === topic ? null : topic))
+                    }
+                    className={cn(
+                      "inline-flex items-center rounded-4xl border px-3 py-1 text-xs font-medium transition-colors",
+                      activeTopic === topic
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border text-foreground hover:bg-muted"
+                    )}
+                  >
+                    {topicLabels[topic] ?? topic}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* Tag filters */}
+            {allTags.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {allTags.map((tag) => (
+                  <button
+                    key={tag}
+                    onClick={() =>
+                      setActiveTag((prev) => (prev === tag ? null : tag))
+                    }
+                    className={cn(
+                      "inline-flex items-center rounded-4xl border px-3 py-1 text-xs font-medium transition-colors",
+                      activeTag === tag
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border text-foreground hover:bg-muted"
+                    )}
+                  >
+                    #{tag}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* Clear filters */}
+            {hasActiveFilters && (
+              <button
+                onClick={clearFilters}
+                className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+              >
+                <RiCloseLine className="size-4" />
+                Clear filters
+              </button>
+            )}
+          </div>
+
+          {/* Post list */}
+          {filtered.length === 0 ? (
+            <p className="text-muted-foreground">No posts match your filters.</p>
+          ) : (
+            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+              {filtered.map((post) => (
+                <BlogPostCard key={post.id} post={post} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const BlogPostCard = ({ post }: { post: BlogPost }) => {
+  const formattedDate = new Date(post.date).toLocaleDateString("en-GB", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const resolvedAuthors = post.authors.map((key) => {
+    const author = siteConfig.blog.authors[key];
+    return author ? author.name : key;
+  });
+
+  const href = `/blog/${post.id}`;
+
+  return (
+    <article className="flex h-full flex-col rounded-md border border-border bg-card p-6">
+      {/* Topics */}
+      {post.topics.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {post.topics.map((topic) => (
+            <Badge key={topic} variant="secondary">
+              {topicLabels[topic] ?? topic}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {/* Title */}
+      <h2 className="text-lg font-semibold tracking-tight leading-snug text-pretty">
+        <a href={href} className="hover:text-primary transition-colors">
+          {post.title}
+        </a>
+      </h2>
+
+      {/* Description */}
+      {post.description && (
+        <p className="mt-2 text-sm text-muted-foreground leading-relaxed line-clamp-3">
+          {post.description}
+        </p>
+      )}
+
+      {/* Tags */}
+      {post.tags && post.tags.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {post.tags.map((tag) => (
+            <Badge key={tag} variant="outline">
+              #{tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* Metadata */}
+      <div className="mt-6 space-y-2 border-t border-border pt-4 text-sm text-muted-foreground">
+        <div className="flex items-center gap-1.5">
+          <RiCalendarLine className="size-4 shrink-0" />
+          <time dateTime={post.date}>{formattedDate}</time>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <RiUser3Line className="size-4 shrink-0" />
+          <span>{resolvedAuthors.join(", ")}</span>
+        </div>
+      </div>
+
+      {/* Read more */}
+      <div className="mt-4">
+        <Button asChild variant="default" size="sm">
+          <a href={href}>
+            Read more
+            <RiArrowRightLine className="size-4" />
+          </a>
+        </Button>
+      </div>
+    </article>
+  );
+};
+
+export { BlogListing, BlogPostCard };

--- a/apps/web-frontend/src/components/blog-post-layout.tsx
+++ b/apps/web-frontend/src/components/blog-post-layout.tsx
@@ -1,0 +1,137 @@
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { siteConfig } from "@/site.config";
+import { cn } from "@/lib/utils";
+import { RiArrowLeftLine, RiCalendarLine, RiPriceTag3Line, RiUser3Line } from "@remixicon/react";
+
+const topicLabels: Record<string, string> = {
+  "general": "General",
+  "server/minigames": "Minigames",
+  "server/modded-creative": "Modded Creative",
+  "server/survival": "Survival",
+};
+
+interface BlogPostLayoutProps {
+  title: string;
+  description?: string;
+  date: string;
+  authors: string[];
+  topics: string[];
+  tags?: string[];
+  children: React.ReactNode;
+  className?: string;
+}
+
+const BlogPostLayout = ({
+  title,
+  description,
+  date,
+  authors,
+  topics,
+  tags,
+  children,
+  className,
+}: BlogPostLayoutProps) => {
+  const formattedDate = new Date(date).toLocaleDateString("en-GB", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const resolvedAuthors = authors.map((key) => {
+    const author = siteConfig.blog.authors[key];
+    return author ?? { name: key, url: undefined };
+  });
+
+  return (
+    <main className={cn("py-12 lg:py-16", className)}>
+      <div className="container mx-auto max-w-3xl px-4">
+        {/* Back link */}
+        <a
+          href="/blog"
+          className="mb-8 inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <RiArrowLeftLine className="size-4" />
+          All posts
+        </a>
+
+        {/* Header */}
+        <header className="mt-4 space-y-4">
+          {/* Topics */}
+          {topics.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {topics.map((topic) => (
+                <Badge key={topic} variant="secondary">
+                  {topicLabels[topic] ?? topic}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          <h1 className="scroll-m-24 text-3xl font-semibold tracking-tight text-pretty sm:text-4xl">
+            {title}
+          </h1>
+
+          {description && (
+            <p className="text-lg text-muted-foreground leading-relaxed">
+              {description}
+            </p>
+          )}
+
+          {/* Metadata row */}
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-muted-foreground">
+            <span className="flex items-center gap-1.5">
+              <RiCalendarLine className="size-4" />
+              <time dateTime={date}>{formattedDate}</time>
+            </span>
+
+            <span className="flex items-center gap-1.5">
+              <RiUser3Line className="size-4" />
+              <span>
+                {resolvedAuthors.map((author, idx) => (
+                  <span key={author.name}>
+                    {author.url ? (
+                      <a
+                        href={author.url}
+                        className="font-medium text-foreground underline-offset-4 hover:underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {author.name}
+                      </a>
+                    ) : (
+                      <span className="font-medium text-foreground">{author.name}</span>
+                    )}
+                    {idx < resolvedAuthors.length - 1 && ", "}
+                  </span>
+                ))}
+              </span>
+            </span>
+          </div>
+
+          {/* Tags */}
+          {tags && tags.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              <RiPriceTag3Line className="size-4 text-muted-foreground" />
+              {tags.map((tag) => (
+                <Badge key={tag} variant="outline">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </header>
+
+        <Separator className="my-8" />
+
+        {/* Body */}
+        <article className="prose-neutral text-neutral-800 dark:text-neutral-300">
+          {children}
+        </article>
+      </div>
+    </main>
+  );
+};
+
+export { BlogPostLayout };
+export type { BlogPostLayoutProps };

--- a/apps/web-frontend/src/pages/[...slug]/index.astro
+++ b/apps/web-frontend/src/pages/[...slug]/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "@/layouts/Layout.astro";
 import DocsLayout from "@/components/docs-layout";
+import { BlogPostLayout } from "@/components/blog-post-layout";
 import { mdxComponents } from "@/components/mdx-components";
 import { getCollection, render } from "astro:content";
 
@@ -20,6 +21,20 @@ export async function getStaticPaths() {
 const { doc } = Astro.props;
 const { Content } = await render(doc);
 const { title, description, template } = doc.data;
+
+// Collect blog posts to pass as props to MDX components that need them
+const allContent = await getCollection("content");
+const blogPosts = allContent
+  .filter((item) => item.data.template === "blog")
+  .map((item) => ({
+    id: item.id,
+    title: item.data.title,
+    description: item.data.description,
+    date: item.data.date,
+    authors: item.data.template === "blog" ? item.data.authors : [],
+    topics: item.data.template === "blog" ? item.data.topics : [],
+    tags: item.data.tags ?? [],
+  }));
 ---
 
 {template === "documentation" && (
@@ -40,15 +55,23 @@ const { title, description, template } = doc.data;
     </Layout>
 )}
 
-{template === "blog" && (
+{template === "blog" && doc.data.template === "blog" && (
     <Layout title={title} description={description}>
-        <Content components={mdxComponents} />
+        <BlogPostLayout
+            title={doc.data.title}
+            description={doc.data.description}
+            date={doc.data.date}
+            authors={doc.data.authors}
+            topics={doc.data.topics}
+            tags={doc.data.tags}
+        >
+            <Content components={mdxComponents} />
+        </BlogPostLayout>
     </Layout>
 )}
 
-
 {template === "plain" && (
     <Layout title={title} description={description}>
-        <Content components={mdxComponents} />
+        <Content components={mdxComponents} blogPosts={blogPosts} />
     </Layout>
 )}

--- a/package.json
+++ b/package.json
@@ -7,5 +7,9 @@
     "build:web": "pnpm --filter web-frontend build",
     "dev:api": "pnpm --filter api-server dev",
     "db:push": "pnpm --filter api-server db:push"
+  },
+  "dependencies": {
+    "@remixicon/react": "^4.9.0",
+    "react": "^19.2.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,14 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    dependencies:
+      '@remixicon/react':
+        specifier: ^4.9.0
+        version: 4.9.0(react@19.2.5)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
 
   apps/api-server:
     dependencies:


### PR DESCRIPTION
- Added `blog-post-layout`, `blog-listing`, and `blog-listing-minimal` components.
- Updated slug page logic to pass blog post data to MDX files.
- Redesigned the minimal blog listing from a simple list into a responsive card grid.
- Fixed duplicated href links across blog navigation components.

[v0 Session](https://v0.app/chat/c6P6VbrQ8W9)